### PR TITLE
Add validatePristineFields option

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -18,6 +18,7 @@ export default class Options {
     validateOnBlur: true,
     validateOnChange: false,
     validateDisabledFields: false,
+    validatePristineFields: true,
     strictUpdate: false,
     strictDelete: true,
     retrieveOnlyDirtyValues: false,

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -101,7 +101,7 @@ export default class Validator {
     // do not validate disabled fields
     if (instance.disabled && !this.form.state.options.get('validateDisabledFields')) return;
     // do not validate pristine fields
-    if (instance.disabled && !this.form.state.options.get('validatePristineFields')) return;
+    if (instance.isPristine && !this.form.state.options.get('validatePristineFields')) return;
     // reset field validation
     instance.resetValidation();
     // validate with all drivers

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -100,6 +100,8 @@ export default class Validator {
     if (!instance.path) throw new Error('Validation Error: Invalid Field Instance');
     // do not validate disabled fields
     if (instance.disabled && !this.form.state.options.get('validateDisabledFields')) return;
+    // do not validate pristine fields
+    if (instance.disabled && !this.form.state.options.get('validatePristineFields')) return;
     // reset field validation
     instance.resetValidation();
     // validate with all drivers


### PR DESCRIPTION
Adds a `validatePristineFields` option.  Setting this to `false` will prevent fields that have not been explicitly changed from being validated. 